### PR TITLE
Scanning the entire /var/qmail/simscan/workdir directory with clamdscan

### DIFF
--- a/simscan.c
+++ b/simscan.c
@@ -107,7 +107,7 @@ int DebugFiles = 0;
 int size_limit = 250000;
 
 /* --stdout is required for reading virus names */
-char *viri_args[] = { "clamdscan", "--stdout", message_name, NULL };
+char *viri_args[] = { "clamdscan", "--stdout", workdir, NULL };
 
 /* To/From address processing globals */
 #define MAX_RCPT_TO 255


### PR DESCRIPTION
Simscan does not scan the entire directory, it only scans the file at /var/qmail/simscan/1748940909.842816.21124/spamc.msg.1748940909.842816.21124

simscan: clamdscan: /var/qmail/simscan/1748940909.842816.21124/spamc.msg.1748940909.842816.21124: OK

Clamdscan cannot always scan this file successfully. I did some research and it turns out that older versions of simscan scan the workdir directory. I made a small change to the simscan.c code to make it work this way.

The line I changed in the simscan.c;

107 char *viri_args[] = { "clamdscan", "--stdout", message_name, NULL };

I corrected this line as follows;

107 char *viri_args[] = { "clamdscan", "--stdout", workdir, NULL };

And now the entire directory is scanned;

simscan: clamdscan: /var/qmail/simscan/1748940909.842816.21124: OK

I hope you will make the necessary corrections to the code. Best regards..