### PR TITLE
This commit enhances the ClamAV integration by logging the full summa…

### DIFF
--- a/simscan.c
+++ b/simscan.c
@@ -963,10 +963,10 @@ int run_ripmime()
 #ifdef ENABLE_CLAMAV
 int check_clam()
 {
- int pid;
- int rmstat;
- int pim[2];
- int file_count;
+  int pid;
+  int rmstat;
+  int pim[2];
+  int file_count;
 
 #ifdef ENABLE_PER_DOMAIN
   if ( PerDomainClam == 0 ) return(-2);
@@ -992,36 +992,40 @@ int check_clam()
       _exit(-1);
   }
   close(pim[1]);
-  dup2(pim[0],0);
-  close(pim[0]);
 
   InClamHeaders = 1;
   memset(buffer,0,sizeof(buffer));
-  while((file_count=read(0,buffer,BUFFER_SIZE))>0) {
-    if ( DebugFlag > 2 ) log_clam(buffer) ;
+  while((file_count=read(pim[0],buffer,BUFFER_SIZE))>0) {
+    log_clam(buffer);
     if ( InClamHeaders == 1 ) {
       is_clam(buffer);
     }
     memset(buffer,0,sizeof(buffer));
   }
+  close(pim[0]);
 
   /* wait for clamdscan to finish */
-  if (waitpid(pid,&rmstat, 0) == -1) { 
+  if (waitpid(pid,&rmstat, 0) == -1) {
+    fprintf(stderr, "simscan: error waiting for clamdscan pid\n");
     return(-1);
   }
 
-  /* check if the child died on a signal */
-  if ( WIFSIGNALED(rmstat) ) return(-1);
+  if ( WIFSIGNALED(rmstat) ) {
+    fprintf(stderr, "simscan: clamdscan terminated by signal\n");
+    return(-1);
+  }
 
 #ifdef ENABLE_RECEIVED
   add_run_scanner(RCVD_CLAM_KEY);
 #endif
-  /* if it exited okay, return the status */ 
+
   if ( WIFEXITED(rmstat) ) {
-    return(WEXITSTATUS(rmstat));
+    int ret = WEXITSTATUS(rmstat);
+    fprintf(stderr, "simscan: clamdscan exited with code %d\n", ret);
+    return ret;
   }
 
-  /* should not reach here */
+  fprintf(stderr, "simscan: unexpected clamdscan termination\n");
   return(-1);
 }
 


### PR DESCRIPTION
This pull request improves the ClamAV scanning process by capturing and logging the full output of clamdscan to stderr. The key changes include:

- Reading and logging clamdscan's stdout output via a pipe.

- Introducing a log_clam() function that prints each line with a consistent prefix (simscan: clamdscan:), aiding clarity during debugging.

- Ensuring logs respect line breaks, skipping carriage returns (\r) and prepending the log prefix at the start of each line.

- The virus detection behavior (is_clam() and VirusName parsing) remains unchanged and works in conjunction with the new logging.

This enhancement makes it easier for system administrators and developers to monitor virus scanning activity and understand what clamdscan outputs during each scan. After revision smtp log appear;

2025-06-05 10:54:36.485141500 simscan:[31923]: calling clamdscan
2025-06-05 10:54:37.474234500 simscan: clamdscan: /var/qmail/simscan/1749110075.712426.31924: OK
2025-06-05 10:54:37.475360500 simscan: clamdscan:
2025-06-05 10:54:37.475689500 simscan: clamdscan: ----------- SCAN SUMMARY -----------
2025-06-05 10:54:37.476401500 simscan: clamdscan: Infected files: 0
2025-06-05 10:54:37.476928500 simscan: clamdscan: Time: 0.976 sec (0 m 0 s)
2025-06-05 10:54:37.477466500 simscan: clamdscan: Start Date: 2025:06:05 10:54:36
2025-06-05 10:54:37.478124500 simscan: clamdscan: End Date: 2025:06:05 10:54:37
2025-06-05 10:54:37.478771500 simscan:[31923]: cdb looking up version clamav
2025-06-05 10:54:37.479160500 simscan: clamdscan exited with code 0

Best regards..

Note: I've made the necessary corrections; I'd appreciate it if you could test it.