### PR TITLE
Contribution Idea: I have a suggestion for RCPT TO user validation.

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,3 +1,15 @@
+
+Todo List - Community Contributions
+
+Add support for validating RCPT TO recipients against a vpopmail+MySQL backend. (#cystein)
+
+  - Useful for configurations where user accounts are stored vpopmail+MySQL.
+  - Simscan should reject messages at RCPT TO stage if recipient is unknown.
+  - Prevents unnecessary virus/spam scanning for invalid recipients.
+
+  
+-------------------------------------------------------------------------------
+
 Todo List - Friz
 
 Logging of message-id along with other information currently logged


### PR DESCRIPTION
Add support for validating RCPT TO recipients against a vpopmail+MySQL backend. 

  - Useful for configurations where user accounts are stored vpopmail+MySQL.
  - Simscan should reject messages at RCPT TO stage if recipient is unknown.
  - Prevents unnecessary virus/spam scanning for invalid recipients.
  
  I haven't thought about the details yet, but I think such a feature would be useful for preventing system resources and backskatter issues. Also, the vpopmail+MySQL server where the mail accounts are located does not have to be on the same machine where the simscan code is running. If simscan is running on a mail gateway, verification can also be done from the remote server where the accounts are located.

What do you think about this?