### PR TITLE
Add DebugFlag and MaxAttach checks to clamdscan logging.

### DIFF
--- a/simscan.c
+++ b/simscan.c
@@ -996,7 +996,9 @@ int check_clam()
   InClamHeaders = 1;
   memset(buffer,0,sizeof(buffer));
   while((file_count=read(pim[0],buffer,BUFFER_SIZE))>0) {
+    if ( DebugFlag > 1 && MaxAttach > 0){
     log_clam(buffer);
+    }
     if ( InClamHeaders == 1 ) {
       is_clam(buffer);
     }


### PR DESCRIPTION
Hi Roberto,

As per your valuable feedback, I have reintroduced the `DebugFlag` control for clamdscan logging. Now, clamdscan output will only be logged when `DebugFlag > 1`.

Additionally, I’ve added a condition to skip logging the clamdscan scan summary if there are no attachments (i.e., when `MaxAttach < 1`). This avoids unnecessary logging for plain text emails.

Thanks again for your helpful insight. I hope this update improves clarity and keeps the logs cleaner.

Best regards,  
Bedreddin